### PR TITLE
Add a publish action to items to allow them to post data to a remote site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem "rubocop-govuk", require: false
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 
+# HTTP Client
+gem "faraday"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]
@@ -63,6 +66,9 @@ group :development, :test do
 
   # Makes randomised data available for testing
   gem "faker"
+
+  # Mock for web calls
+  gem "webmock"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,12 +66,18 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    bigdecimal (3.1.6)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
     concurrent-ruby (1.2.3)
+    crack (0.4.6)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
@@ -88,6 +94,10 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
     govuk-components (5.1.0)
@@ -99,6 +109,7 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 1)
+    hashdiff (1.1.0)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     i18n (1.14.1)
@@ -127,6 +138,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.22.2)
     msgpack (1.7.2)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.10)
       date
       net-protocol
@@ -154,6 +167,7 @@ GEM
       railties (>= 7.0.0)
     psych (5.1.2)
       stringio
+    public_suffix (5.0.4)
     puma (5.6.8)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -260,6 +274,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     view_component (3.10.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -269,6 +284,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.20.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -284,6 +303,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  faraday
   govuk-components
   govuk_design_system_formbuilder
   jbuilder
@@ -298,6 +318,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/controllers/esdas_controller.rb
+++ b/app/controllers/esdas_controller.rb
@@ -1,5 +1,6 @@
 class EsdasController < ApplicationController
   before_action :set_esda, only: %i[show update destroy]
+  skip_before_action :verify_authenticity_token
 
   # GET /esdas
   # GET /esdas.json
@@ -14,7 +15,7 @@ class EsdasController < ApplicationController
   # POST /esdas
   # POST /esdas.json
   def create
-    @esda = Esda.new(esda_params)
+    @esda = Esda.new(metadata: params.dig(:esda, :metadata))
 
     if @esda.save
       render :show, status: :created, location: @esda

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,6 +7,10 @@
   <pre>
 <%= JSON.pretty_generate(@item.metadata) %>
   </pre>
+  <% if @item.esda_id? %>
+    <h2 class="govuk-heading-m">ESDA ID</h2>
+    <p><%= @item.esda_id %></p>
+  <% end %>
 </div>
 
 <div>
@@ -16,4 +20,6 @@
   </p>
 
   <%= button_to "Destroy this item", @item, method: :delete, class: "govuk-button govuk-button--warning" %>
+
+  <%= button_to "Publish", publish_item_path(@item), method: :post, class: "govuk-button" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   resources :esdas, constraints: ->(req) { req.format == :json }
-  resources :items
+  resources :items do
+    member do
+      post :publish
+    end
+  end
   root "home#index"
 end

--- a/db/migrate/20240313114652_add_esda_id_to_items.rb
+++ b/db/migrate/20240313114652_add_esda_id_to_items.rb
@@ -1,0 +1,5 @@
+class AddEsdaIdToItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :items, :esda_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_12_152119) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_13_114652) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_12_152119) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "last_completed_step"
+    t.string "esda_id"
   end
 
 end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -100,4 +100,29 @@ RSpec.describe "/items", type: :request do
       expect(response).to redirect_to(items_url)
     end
   end
+
+  describe "publish /publish" do
+    subject(:publish) { post publish_item_path(item) }
+    let(:esda_id) { SecureRandom.uuid }
+
+    before do
+      stub_request(:post, ItemsController::PUBLISH_URL).with(
+        body: { esda: { metadata: item.metadata } }.to_json,
+      ).to_return(
+        status: 200,
+        body: { id: esda_id }.to_json,
+        headers: { "content-type" => "application/json" },
+      )
+    end
+
+    it "renders successfully" do
+      publish
+      expect(response).to redirect_to(item_path(item))
+    end
+
+    it "stores the esda id on the item" do
+      publish
+      expect(item.reload.esda_id).to eq(esda_id)
+    end
+  end
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,1 @@
+require "webmock/rspec"


### PR DESCRIPTION
Note that it is possible to post from the new items publish view to the esdas controller. However, if you try doing that in development with only one instance of the app running, the connection will time out because the app is unable to handle the new HTTP request while it is still trying to process the current one.

I was able to test the set up locally by running two instances of the app. To do this I opened two consoles and entered each with one of these two commands:

- Client: `PUBLISH_URL=http://localhost:3001/esdas.json rails s`
- API endpoint: `rails s -p 3001 -P 333`